### PR TITLE
Add comment display feature

### DIFF
--- a/docs/en/syntax.txt
+++ b/docs/en/syntax.txt
@@ -3,7 +3,7 @@
 =======================
 
 
-Some relevant parts of this section were copied from 
+Some relevant parts of this section were copied from
 the `official Slim documentation <https://github.com/slim-template/slim>`_.
 
 Line Indicators
@@ -51,14 +51,17 @@ Line Indicators
       This line indicator has been considered redundant since Plim supports raw HTML tags:
 
       .. code-block:: plim
-    
+
           / You can use raw HTML comment tags, as well as all other tags
           <!-- HTML comment -->
+
+          / Or You can use "/!"
+          /! HTML comment
           <div>
-    
+
             / You can use Plim markup inside the raw HTML
             a href="#" = link.title
-    
+
           / If you use raw HTML, you have to close all tags manually
           </div>
 
@@ -66,7 +69,7 @@ Line Indicators
 Indentation
 ==================
 
-Plim indentation rules are the same as of Slim: indentation matters, but it's not as strict as 
+Plim indentation rules are the same as of Slim: indentation matters, but it's not as strict as
 `Haml <http://haml.info/about.html>`_.
 If you want to first indent 2 spaces, then 5 spaces, it's your choice. To nest markup you only need to
 indent by one space, the rest is gravy.
@@ -89,7 +92,7 @@ For example
 will be rendered as
 
 .. code-block:: html
-    
+
     <input type="text" name="username" value="Max Power" maxlength="32"/>
 
 As in Python string declarations, you must take care of correct quote escaping
@@ -100,7 +103,7 @@ As in Python string declarations, you must take care of correct quote escaping
     input value="It's simple"
     input value='''It's simple'''
     input value="""It's simple"""
-    
+
     input value="He said \"All right!\""
     input value='He said "All right!"'
     input value='''He said "All right!"'''
@@ -128,14 +131,14 @@ Dynamic values can be specified in forms of:
 - Mako expression
 
   .. code-block:: plim
-  
+
       input type="text" name="username" value="${user.name}" maxlength=32
       a href="${request.route_url('user_profile', tagname=user.login, _scheme='https')}"
-  
+
   or
-  
+
   .. code-block:: plim
-  
+
       input type="text" name="username" value=${user.name} maxlength=32
       a href=${request.route_url('user_profile', tagname=user.login, _scheme='https')}
 
@@ -143,21 +146,21 @@ Dynamic values can be specified in forms of:
 - Python expression
 
   .. code-block:: plim
-  
+
       input type="text" name="username" value=user.name maxlength=32
       a href=request.route_url('user_profile', tagname=user.login, _scheme='https')
-  
+
   or with parentheses
-  
+
   .. code-block:: plim
-  
+
       input type="text" name="username" value=(user.name) maxlength=32
       a href=(request.route_url('user_profile', tagname=user.login, _scheme='https'))
 
 All these examples produce the same mako markup:
 
 .. code-block:: mako
-  
+
     <input type="text" name="username" value="${user.name}" maxlength="32"/>
     <a href="${request.route_url('user_profile', tagname=user.login, _scheme='https')}"></a>
 
@@ -173,7 +176,7 @@ Static attribute example:
 
     / Static boolean attribute "disabled"
     input type="text" name="username" disabled="disabled"
-    
+
     / If you wrap your attributes with parentheses, you can use
       shortcut form
     input (type="text" name="username" disabled)
@@ -185,14 +188,14 @@ Dynamic attribute example (note the trailing question mark):
     / Dynamic boolean attribute "disabled"
       will be evaluated to 'disabled="disabled"' if `is_disabled`
       evaluates to True
-      
+
     input type="text" name="username" disabled=${is_disabled}?
-    
+
     / or you can write it that way
     input type="text" name="username" disabled=is_disabled?
-    
+
     / or even that way
-    input type="text" name="username" disabled=(is_disabled or 
+    input type="text" name="username" disabled=(is_disabled or
                                                 is_really_disabled)?
 
 
@@ -510,7 +513,7 @@ Use forward slash ``/`` for code comments
 Raw HTML Tags
 ====================================
 
-Plim allows you to use raw HTML tag lines, and also to mix them with any 
+Plim allows you to use raw HTML tag lines, and also to mix them with any
 available control logic. It is particularly useful in situations like this one:
 
 .. code-block:: plim
@@ -546,11 +549,11 @@ Here is the full list of available doctypes:
 **doctype 5**
 
     ``<!DOCTYPE html>``
-  
+
 **doctype 1.1**
 
     ``<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">``
-  
+
 **doctype strict**
 
     ``<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">``
@@ -566,11 +569,11 @@ Here is the full list of available doctypes:
 **doctype frameset**
 
     ``<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Frameset//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-frameset.dtd">``
-    
+
 **doctype basic**
 
     ``<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML Basic 1.1//EN" "http://www.w3.org/TR/xhtml-basic/xhtml-basic11.dtd">``
-    
+
 **doctype mobile**
 
     ``<!DOCTYPE html PUBLIC "-//WAPFORUM//DTD XHTML Mobile 1.2//EN" "http://www.openmobilealliance.org/tech/DTD/xhtml-mobile12.dtd">``
@@ -635,7 +638,7 @@ See the section :ref:`Returning Early from a Template <return-early>`.
    -python
      i = 0
      limit = 5
-   
+
    ul
      -while i < limit
        li#idx-${i}.up: a href='#' title="Title" == i
@@ -665,14 +668,14 @@ See the section :ref:`Returning Early from a Template <return-early>`.
 **with** statement
 ---------------------
 
-The ``% with`` statement was introduced in 
+The ``% with`` statement was introduced in
 `Mako 0.7.0 <http://www.makotemplates.org/CHANGES>`_.
 
 .. code-block:: plim
 
     -with <EXPR> as <VAR>
       / Do some stuff
-    
+
 
 **try/except** statements
 ---------------------------
@@ -682,10 +685,10 @@ The ``% with`` statement was introduced in
     - try
       div = item[0]
       div = price['usd']
-      
+
     - except IndexError
       div IndexError
-      
+
     - except KeyError as e
       div = e
 
@@ -695,7 +698,7 @@ The ``% with`` statement was introduced in
 Returning Early from a Template
 --------------------------------
 
-Plim provides a shortcut to Mako's 
+Plim provides a shortcut to Mako's
 `<% return %> <http://docs.makotemplates.org/en/latest/syntax.html#returning-early-from-a-template>`_
 template directive.
 
@@ -790,10 +793,10 @@ Literal blocks can be implicitly specified by the following starting sequences:
     p
       | pipe is the explicit literal indicator. It is required if your line starts with
         the non-literal character.
-    
+
     p
       I'm the implicit literal, because my first letter is in uppercase.
-    
+
     p
       1. Digits
       2. are
@@ -801,10 +804,10 @@ Literal blocks can be implicitly specified by the following starting sequences:
       4. implicit
       5. literals
       6. too.
-    
+
     p
       ${raw_mako_expression} indicates the implicit literal line.
-    
+
     p
       If subsequent lines do not start with implicit literal indicator,
         you must indent them
@@ -814,12 +817,12 @@ Literal blocks can be implicitly specified by the following starting sequences:
 .. only:: html
 
     .. code-block:: plim
-    
+
         p
           если ваш блок текста написан на русском, или любом другом языке, не
           использующим символы из ASCII-диапазона, то вам даже не обязательно
           использовать заглавную букву в начале блока.
-        
+
           / if your literal blocks are written in Russian, or any other
             language which uses non-ASCII letters, you can put even the
             lowercase letter at the beginning of the block
@@ -828,19 +831,19 @@ Literal blocks can be implicitly specified by the following starting sequences:
 .. only:: latex
 
     .. code-block:: plim
-    
+
         p
-          / if your literal blocks are written in Russian, or any other 
-            language which uses non-ASCII letters, you can put even the 
+          / if your literal blocks are written in Russian, or any other
+            language which uses non-ASCII letters, you can put even the
             lowercase letter at the beginning of the block
-            
+
             Unfortunately, we cannot provide an example of this feature here,
             because current version of Sphinx Documenting tool cannot automatically
             build PDF documentation with unicode characters.
-            See an explanation on 
+            See an explanation on
             https://groups.google.com/forum/#!topic/sphinx-dev/kUeROyCyX9w/discussion
 
-      
+
 
 
 Python Blocks
@@ -848,7 +851,7 @@ Python Blocks
 
 Classic Blocks
 --------------
-Use ``-py`` or ``-python`` to insert the 
+Use ``-py`` or ``-python`` to insert the
 `<% %> mako tag <http://docs.makotemplates.org/en/latest/syntax.html#python-blocks>`_.
 
 For example
@@ -953,7 +956,7 @@ the result (indentation will be stripped out):
 Module-level Blocks
 ========================
 
-Use ``-py!`` or ``-python!`` block to insert the 
+Use ``-py!`` or ``-python!`` block to insert the
 `<%! %> mako tag <http://docs.makotemplates.org/en/latest/syntax.html#module-level-blocks>`_.
 
 .. code-block:: plim
@@ -980,12 +983,12 @@ Use ``-py!`` or ``-python!`` block to insert the
 Mako Tags
 ===========================
 
-Plim supports a complete set of 
+Plim supports a complete set of
 `Mako Tags <http://docs.makotemplates.org/en/latest/syntax.html#tags>`_,
 except the ``<%doc>``. The latter has been considered deprecated, since
 Plim itself has built-in support of multi-line comments.
 
-.. note:: As all mako tags start with the ``<`` char, which 
+.. note:: As all mako tags start with the ``<`` char, which
     indicates a :ref:`raw HTML line <raw-html>`, they all can be written
     "as is". The only thing you must remember is to manually close the pair tags.
 
@@ -1003,7 +1006,7 @@ produces
 
     <%page args="x, y, z='default'"/>
 
-See the details of what ``<%page>`` is used for in 
+See the details of what ``<%page>`` is used for in
 `The body() Method <http://docs.makotemplates.org/en/latest/namespaces.html#namespaces-body>`_
 and `Caching <http://docs.makotemplates.org/en/latest/caching.html>`_
 sections of Mako Documentation.
@@ -1014,7 +1017,7 @@ sections of Mako Documentation.
 -------------------
 
 .. code-block:: plim
-    
+
     -include footer.html
 
 or
@@ -1026,7 +1029,7 @@ or
 produce the same output
 
 .. code-block:: mako
-    
+
     <%include file="footer.html"/>
 
 
@@ -1037,13 +1040,13 @@ of Mako Documentation to get more information about this tag.
 -------------------
 
 .. code-block:: plim
-    
+
     -inherit base.html
 
 or
 
 .. code-block:: plim
-    
+
     -inherit file="base.html"
 
 will generate the same
@@ -1051,8 +1054,8 @@ will generate the same
 .. code-block:: mako
 
     <%inherit file="base.html"/>
-    
-See Mako's `inheritance documentation <http://docs.makotemplates.org/en/latest/inheritance.html>`_ 
+
+See Mako's `inheritance documentation <http://docs.makotemplates.org/en/latest/inheritance.html>`_
 to get more information about template inheritance.
 
 **-namespace** tag
@@ -1074,7 +1077,7 @@ produce
 
     <%namespace file="helpers.html" name="helper"/>
 
-See Mako's `namespace documentation <http://docs.makotemplates.org/en/latest/namespaces.html>`_ 
+See Mako's `namespace documentation <http://docs.makotemplates.org/en/latest/namespaces.html>`_
 to get more information about template namespaces.
 
 
@@ -1084,7 +1087,7 @@ to get more information about template namespaces.
 .. code-block:: plim
 
     -def account(accountname, type='regular')
-    
+
 or
 
 .. code-block:: plim
@@ -1098,7 +1101,7 @@ produce
     <%def name="account(accountname, type='regular')">
     </%def>
 
-See Mako's `defs and blocks documentation <http://docs.makotemplates.org/en/latest/defs.html>`_ 
+See Mako's `defs and blocks documentation <http://docs.makotemplates.org/en/latest/defs.html>`_
 to get more information about functions and blocks.
 
 
@@ -1141,7 +1144,7 @@ You can also specify other block arguments as well
       html this is some escaped html.
 
 
-See Mako's `defs and blocks documentation <http://docs.makotemplates.org/en/latest/defs.html>`_ 
+See Mako's `defs and blocks documentation <http://docs.makotemplates.org/en/latest/defs.html>`_
 to get more information about functions and blocks.
 
 
@@ -1156,13 +1159,13 @@ The following examples
 
     -call expression="${4==4}" self:conditional
       |i'm the result
-    
+
     - call expression=${4==4} self:conditional
       | i'm the result
-    
+
     - call self:conditional
       | i'm the result
-    
+
     - call self:conditional
 
 will produce
@@ -1172,22 +1175,22 @@ will produce
     <%self:conditional expression="${4==4}">
     i'm the result
     </%self:conditional>
-    
+
     <%self:conditional expression="${4==4}">
     i'm the result
     </%self:conditional>
-    
+
     <%self:conditional>
     i'm the result
     </%self:conditional>
-    
+
     <%self:conditional>
     </%self:conditional>
 
 
 Please consult the sections
 `<%nsname:defname> <http://docs.makotemplates.org/en/latest/syntax.html#nsname-defname>`_
-and 
+and
 `Calling a Def with Embedded Content and/or Other Defs <http://docs.makotemplates.org/en/latest/defs.html#defs-with-content>`_
 of Mako Documentation to get more information about custom tags.
 
@@ -1196,10 +1199,10 @@ of Mako Documentation to get more information about custom tags.
 **-text** tag
 ----------------
 
-As it is mentioned in 
-`Mako documentation <http://docs.makotemplates.org/en/latest/syntax.html#text>`_, 
-this tag suspends the Mako lexer’s normal parsing of Mako template directives, 
-and returns its entire body contents as plain text. It is used pretty much to write 
+As it is mentioned in
+`Mako documentation <http://docs.makotemplates.org/en/latest/syntax.html#text>`_,
+this tag suspends the Mako lexer’s normal parsing of Mako template directives,
+and returns its entire body contents as plain text. It is used pretty much to write
 documentation about Mako:
 
 .. code-block:: plim
@@ -1207,16 +1210,16 @@ documentation about Mako:
     -text filter="h"
       here's some fake mako ${syntax}
       <%def name="x()">${x}</%def>
-    
+
     - text filter="h" here's some fake mako ${syntax}
       <%def name="x()">${x}</%def>
-    
+
     - text filter="h" = syntax
       <%def name="x()">${x}</%def>
-    
+
     -text
       here's some fake mako ${syntax}
       <%def name="x()">${x}</%def>
-    
+
     -text , here's some fake mako ${syntax}
       <%def name="x()">${x}</%def>

--- a/plim/lexer.py
+++ b/plim/lexer.py
@@ -1038,7 +1038,7 @@ def parse_call(indent_level, current_line, matched, source, syntax):
     return joined(buf), 0, '', source
 
 
-def parse_comment(indent_level, __, ___, source, syntax):
+def parse_comment(indent_level, tail_line, __, source, syntax):
     """
 
     :param indent_level:
@@ -1050,15 +1050,20 @@ def parse_comment(indent_level, __, ___, source, syntax):
     :return:
     """
     while True:
-        try:
-            lineno, tail_line = next(source)
-        except StopIteration:
-            break
         tail_indent, tail_line = scan_line(tail_line)
-        if not tail_line:
-            continue
-        if tail_indent <= indent_level:
-            return '', tail_indent, tail_line, source
+        if tail_line.strip().startswith('/!'):
+            tail_line = tail_line[2:]
+            return joined(['<!-- ', tail_line.strip(), ' -->']), indent_level, '', source
+        else:
+            try:
+                lineno, tail_line = next(source)
+            except StopIteration:
+                break
+            tail_indent, tail_line = scan_line(tail_line)
+            if not tail_line:
+                continue
+            if tail_indent <= indent_level:
+                return '', tail_indent, tail_line, source
     return '', 0, '', source
 
 

--- a/tests/fixtures/comment_result.mako
+++ b/tests/fixtures/comment_result.mako
@@ -1,1 +1,1 @@
-<div>Test 1</div><div>Test 2</div><div><nav style="display:inline;margin-left:10px">${_('Interface')}:<span id="more-languages"></span></nav></div>
+<!-- This is a comment can display in html --><div>Test 1</div><div>Test 2</div><div><nav style="display:inline;margin-left:10px"><!-- In nested structure to display in nav --><span id="nested"></span>${_('Interface')}:<span id="more-languages"></span></nav></div>

--- a/tests/fixtures/comment_test.plim
+++ b/tests/fixtures/comment_test.plim
@@ -1,3 +1,4 @@
+/! This is a comment can display in html
 / This is a comment.
   You can comment-out entire block with indentation
 div Test 1
@@ -12,6 +13,8 @@ div Test 2
 //////////////////////////
 div
     nav style='display:inline;margin-left:10px'
+        /! In nested structure to display in nav
+            span#nested
         /
             Let's test empty-line-after-comment behaviour
 

--- a/tests/fixtures/unicode_attributes_result.mako
+++ b/tests/fixtures/unicode_attributes_result.mako
@@ -1,1 +1,1 @@
-<a title="quick unicode string in 中文"></a><input placeholder="${u"選擇"}"/>
+<!-- This is a comment can display in html include 中文 --><a title="quick unicode string in 中文"></a><input placeholder="${u"選擇"}"/>

--- a/tests/fixtures/unicode_attributes_test.plim
+++ b/tests/fixtures/unicode_attributes_test.plim
@@ -1,2 +1,3 @@
+/! This is a comment can display in html include 中文
 a title="quick unicode string in 中文"
 input (placeholder=(u"選擇"))


### PR DESCRIPTION
I often write some comments to html. Although directly I can use like this:

```
<!-- HTML comment -->
```

but i think also can use

```
/! HTML comment
```

In [Slim](http://slim-lang.com/) it has implemented.
