### PR TITLE
Fix plimc error when use custom_module

### DIFF
--- a/plim/console.py
+++ b/plim/console.py
@@ -42,6 +42,7 @@ def plimc(args=None, stdout=None):
     # Get custom preprocessor, if specified
     # -------------------------------------
     preprocessor_path = args.preprocessor
+    sys.path.append('')
     preprocessor = EntryPoint.parse('x={}'.format(preprocessor_path)).load(False)
 
     # Render to html, if requested


### PR DESCRIPTION
I have a custom module want using extensions API

```
$cat a.py
import re
from plim import preprocessor_factory
from plim.util import joined

PARSE_DISPLAY_COMMENT_RE = re.compile('/!.*')

def parse_can_display_comment(indent_level, current_line, matched, source, syntax):
    return joined(['<!-- ', current_line[2:], ' -->']), indent_level, '', source

CUSTOM_PARSERS = [
    (PARSE_DISPLAY_COMMENT_RE, parse_can_display_comment)
]

custom_preprocessor = preprocessor_factory(custom_parsers=CUSTOM_PARSERS, syntax='mako')
```

But when i use plimc, It raise this:

```
$plimc -p a:custom_preprocessor a.plim
Traceback (most recent call last):
  File "/Users/dongweiming/test_plim/venv/bin/plimc", line 9, in <module>
    load_entry_point('Plim==0.9.9', 'console_scripts', 'plimc')()
  File "build/bdist.macosx-10.9-intel/egg/plim/console.py", line 45, in plimc
  File "/Users/dongweiming/test_plim/venv/lib/python2.7/site-packages/pkg_resources.py", line 2048, in load
    entry = __import__(self.module_name, globals(),globals(), ['__name__'])
ImportError: No module named a
```

when i use ipython it's works:

```
$ipython
In [1]: from pkg_resources import EntryPoint
In [2]: EntryPoint.parse('x={}'.format('a:custom_preprocessor')).load(False)
Out[2]: <functools.partial at 0x102259940>
In [3]: import sys
In [4]: '' in sys.path
Out[4]: True
```

And use defualt preprocessor(plim:preprocessor) is also works.

Because the default can import:

```
$python
>>> from plim import preprocessor
```

I found that after commissioning because sys.path which perform EntryPoint call has no current directory.

I add this line in `venv/lib/python2.7/site-packages/pkg_resources.py` L 2048

```
def load(self, require=True, env=None, installer=None):                                                             
        if require: self.require(env, installer)         
        print '' in sys.path # I add this                                                               
        entry = __import__(self.module_name, globals(),globals(), ['__name__'])                                         
        for attr in self.attrs:                                                                                         
            try:                                                                                                        
                entry = getattr(entry,attr)                                                                             
            except AttributeError:                                                                                      
                raise ImportError("%r has no %r attribute" % (entry,attr))                                              
        return entry
```

It's False
