### PR TITLE
TemplateLookup need default filter && render_unicode disregards the output encoding keyword argument

### DIFF
--- a/plim/console.py
+++ b/plim/console.py
@@ -54,7 +54,7 @@ def plimc(args=None, stdout=None):
         template_file = os.path.basename(args.source)
         lookup = TemplateLookup(directories=[root_dir],
                                 input_encoding=args.encoding,
-                                output_encoding=args.encoding,
+                                default_filters=['decode.utf8'],
                                 preprocessor=preprocessor)
         content = lookup.get_template(template_file).render_unicode()
     else:


### PR DESCRIPTION
I like plimc for my test. But there is a problem. such as the following examples:

```
$cat a.plim
html
body
  p ${"中文"}
$plimc -H -p a:custom_preprocessor a.plim
Traceback (most recent call last):
  File "/Users/dongweiming/test_plim/venv/bin/plimc", line 9, in <module>
    load_entry_point('Plim==0.9.10', 'console_scripts', 'plimc')()
  File "build/bdist.macosx-10.9-intel/egg/plim/console.py", line 60, in plimc
  File "/Users/dongweiming/test_plim/venv/lib/python2.7/site-packages/Mako-0.9.1-py2.7.egg/mako/template.py", line 452, in render_unicode
    as_unicode=True)
  File "/Users/dongweiming/test_plim/venv/lib/python2.7/site-packages/Mako-0.9.1-py2.7.egg/mako/runtime.py", line 807, in _render
    **_kwargs_for_callable(callable_, data))
  File "/Users/dongweiming/test_plim/venv/lib/python2.7/site-packages/Mako-0.9.1-py2.7.egg/mako/runtime.py", line 839, in _render_context
    _exec_template(inherit, lclcontext, args=args, kwargs=kwargs)
  File "/Users/dongweiming/test_plim/venv/lib/python2.7/site-packages/Mako-0.9.1-py2.7.egg/mako/runtime.py", line 865, in _exec_template
    callable_(context, *args, **kwargs)
  File "a_plim", line 21, in render_body
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe4 in position 0: ordinal not in range(128)
```

I think need add [default_filters](http://docs.makotemplates.org/en/latest/filtering.html#filtering-default-filters). and when I read the document. Find the following description in [usage.html](http://docs.makotemplates.org/en/latest/usage.html):

```
Additionally, the render_unicode() method exists which will return the template output as a Python unicode object, or in Python 3 a string:

print mytemplate.render_unicode()
```
