### PR TITLE
Fix minor doc typo

### DIFF
--- a/docs/differences.rst
+++ b/docs/differences.rst
@@ -61,7 +61,7 @@ Plim is *not the exact* port of Slim. Here is the full list of differences.
 #.  In Plim, all html tags **MUST** be written in lowercase.
 
     This restriction was introduced to support
-    :ref:`Implicit Litaral Blocks <implicit-literals>` feature.
+    :ref:`Implicit Literal Blocks <implicit-literals>` feature.
 
     .. code-block:: slim
 

--- a/docs/locale/differences.pot
+++ b/docs/locale/differences.pot
@@ -58,7 +58,7 @@ msgstr ""
 
 #: ../differences.rst:63
 # 2a470b5d41b548dda64bed052f282a56
-msgid "This restriction was introduced to support :ref:`Implicit Litaral Blocks <implicit-literals>` feature."
+msgid "This restriction was introduced to support :ref:`Implicit Literal Blocks <implicit-literals>` feature."
 msgstr ""
 
 #: ../differences.rst:79

--- a/docs/locale/zh_CN/LC_MESSAGES/differences.po
+++ b/docs/locale/zh_CN/LC_MESSAGES/differences.po
@@ -65,10 +65,10 @@ msgstr "Plim 中，所有 HTML 标签 **必须** 完全小写："
 
 #: ../differences.rst:63
 msgid ""
-"This restriction was introduced to support :ref:`Implicit Litaral Blocks "
+"This restriction was introduced to support :ref:`Implicit Literal Blocks "
 "<implicit-literals>` feature."
 msgstr ""
-"该限制是为了提供 :ref:`隐式纯文本块（Implicit Litaral Blocks） <implicit-literals>` 功能。"
+"该限制是为了提供 :ref:`隐式纯文本块（Implicit Literal Blocks） <implicit-literals>` 功能。"
 
 #: ../differences.rst:79
 msgid ""


### PR DESCRIPTION
`Litaral` should be spelled `Literal`.